### PR TITLE
Update resnet20-ultra96v2.md

### DIFF
--- a/content/en/docs/Tutorials/resnet20-ultra96v2.md
+++ b/content/en/docs/Tutorials/resnet20-ultra96v2.md
@@ -146,9 +146,9 @@ Double-click it. Disable "Scatter Gather Engine" and "Write Channel". Change "Wi
 
 ![dma](/images/tutorials/resnet20-ultra96v2/dma.png)
 
-Connect the `instruction` port on the Tensil `top` block to `M_AXIS_MM2S` on the AXI DMA block. Then, connect `M_AXI_MM2S` on the AXI DMA block to `S_AXI_HP1_FPD` on Zynq.
+Connect the `instruction` port on the Tensil `top` block to `M_AXIS_MM2S` on the AXI DMA block. Then, connect `M_AXI_MM2S` on the AXI DMA block to `S_AXI_HP3_FPD` on Zynq.
 
-Once again, click the plus `+` button in the Block Diagram toolbar and select "AXI SmartConnect. The SmartConnect is necessary to expose DMA control registers to the Zynq CPU, which will enable software to control the DMA transactions. Double-click it and set "Number of Slave and Master Interfaces" to 1. 
+Once again, click the plus `+` button in the Block Diagram toolbar and select "AXI SmartConnect". The SmartConnect is necessary to expose DMA control registers to the Zynq CPU, which will enable software to control the DMA transactions. Double-click it and set "Number of Slave and Master Interfaces" to 1. 
 
 ![smartconnect](/images/tutorials/resnet20-ultra96v2/smartconnect.png)
 


### PR DESCRIPTION
if one is to trust the block diagram:

![image](https://user-images.githubusercontent.com/54891577/172397108-17fc99cd-aa4e-40d0-997c-3bf86763abec.png)

 then it should say that `M_AXI_MM2S` should be connected to the AXI DMA block to `S_AXI_HP3_FPD`, not to `S_AXI_HP1_FPD`

`S_AXI_HP1_FPD` and `S_AXI_HP2_FPD` have been used in a previous step - so `S_AXI_HP3_FPD` is the only one left at that stage in the instructions